### PR TITLE
Closes #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ target/
 *.zip
 *.tar.gz
 *.rar
+# Temp files from using bash scripts
+*.un~

--- a/README.adoc
+++ b/README.adoc
@@ -2,4 +2,7 @@
 
 == PREREQUISITES
 
+IMPORTANT: First go to `git-hooks` directory,
+use `chmod +x add-hooks` and then `./add-hooks` to activate git hooks.
+
 == RUNNING

--- a/git-hooks/add-hooks
+++ b/git-hooks/add-hooks
@@ -1,0 +1,2 @@
+#!/bin/sh
+chmod +x pre-commit | cp pre-commit ../.git/hooks

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# Prevent git commit if mvn package fail
+echo "Building project..."
+if $(mvn clean package -q)
+then
+	echo "Build succeed"
+else
+	echo "Build failed"
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+exec git diff-index --check --cached $against --


### PR DESCRIPTION
Create a basic git hook to prevent commit if mvn package fail. Rest of
pre-commit hook remains unchanged as in an example.

Additionally created a script to copy hook to it's a destination, update README and .gitignore.